### PR TITLE
MRKT-338 Update dependencies in marketo-rest-sdk-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.smartling.marketo</groupId>
     <artifactId>marketo-sdk</artifactId>
-    <version>3.1.24</version>
+    <version>3.1.25-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jersey.version>2.33</jersey.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jersey.version>2.35</jersey.version>
+        <jackson.version>2.13.0-rc2</jackson.version>
 
         <integration.tests.location>com/smartling/it/**/*.java</integration.tests.location>
     </properties>


### PR DESCRIPTION
I decrease jersey version because 3.x.x version is not compatible with Spring boot version in the marketo-provider and it impossible to override version of jersey and jackson artifact